### PR TITLE
Update countries.yaml

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -7130,9 +7130,10 @@ VN:
   ioc: VIE
   latitude: "16 10 N"
   longitude: "107 50 E"
-  name: "Viet Nam"
+  name: "Vietnam"
   names:
     - "Vietnam"
+    - "Viet Nam"
   national_destination_code_lengths:
     - 2
   national_number_lengths:


### PR DESCRIPTION
Made "Vietnam" the more acceptable spelling of "Viet Nam". (Wikipedia says either is acceptable, although the latter technically contains an "e" with a hook and circumflex instead of the standard Latin letter.)