### PR TITLE
Remove Singapore subdivisions

### DIFF
--- a/lib/countries/version.rb
+++ b/lib/countries/version.rb
@@ -1,3 +1,3 @@
 module Countries
-  VERSION = "0.9.14"
+  VERSION = '0.9.15'
 end

--- a/lib/data/subdivisions/SG.yaml
+++ b/lib/data/subdivisions/SG.yaml
@@ -1,4 +1,0 @@
----
-X1~:
-  name: "Singapore - No State"
-  names: "Singapore - No State"


### PR DESCRIPTION
`Country` will ignore subdivisions if a data file does not exist, so removing this file that says that there are no subdivisions will leave us with an empty list, as expected.