### PR TITLE
BR-2848 Remove 'East Melbourne' as a subdivision in AU

### DIFF
--- a/lib/countries/version.rb
+++ b/lib/countries/version.rb
@@ -1,3 +1,3 @@
 module Countries
-  VERSION = '0.9.16'
+  VERSION = '0.9.17'
 end

--- a/lib/data/subdivisions/AU.yaml
+++ b/lib/data/subdivisions/AU.yaml
@@ -20,9 +20,6 @@ TAS:
 VIC:
   name: Victoria
   names: Victoria
-EM:
-  name: "East Melbourne"
-  names: "East Melbourne"
 WA:
   name: "Western Australia"
   names: "Western Australia"


### PR DESCRIPTION
Apparently, it's not actually a state

https://namely.atlassian.net/browse/BR-2848