### PR TITLE
[BR-5581] Fix China state IDs

### DIFF
--- a/lib/countries/version.rb
+++ b/lib/countries/version.rb
@@ -1,3 +1,3 @@
 module Countries
-  VERSION = '0.9.18'
+  VERSION = '0.9.19'
 end

--- a/lib/data/subdivisions/CN.yaml
+++ b/lib/data/subdivisions/CN.yaml
@@ -1,149 +1,149 @@
 ---
-? "11"
+? "BJ"
 :
   name: Beijing
   names:
     - Beijing
     - Pekín
-? "12"
+? "TJ"
 :
   name: Tianjin
   names: Tianjin
-? "13"
+? "HE"
 :
   name: Hebei
   names: Hebei
-? "14"
+? "SX"
 :
   name: Shanxi
   names: Shanxi
-? "15"
+? "NM"
 :
   name: "Nei Mongol (mn)"
   names:
     - "Inner Mongolia"
     - "Nei Monggol"
-? "21"
+? "LN"
 :
   name: Liaoning
   names: Liaoning
-? "22"
+? "JL"
 :
   name: Jilin
   names: Jilin
-? "23"
+? "HL"
 :
   name: Heilongjiang
   names: Heilongjiang
-? "31"
+? "SH"
 :
   name: Shanghai
   names:
     - Schanghai
-? "32"
+? "JS"
 :
   name: Jiangsu
   names: Jiangsu
-? "33"
+? "ZJ"
 :
   name: Zhejiang
   names: Zhejiang
-? "34"
+? "AH"
 :
   name: Anhui
   names: Anhui
-? "35"
+? "FJ"
 :
   name: Fujian
   names: Fujian
-? "36"
+? "JX"
 :
   name: Jiangxi
   names: Jiangxi
-? "37"
+? "SD"
 :
   name: Shandong
   names: Shandong
-? "41"
+? "HA"
 :
   name: Henan
   names: Henan
-? "42"
+? "HB"
 :
   name: Hubei
   names: Hubei
-? "43"
+? "HN"
 :
   name: Hunan
   names: Hunan
-? "44"
+? "GD"
 :
   name: Guangdong
   names: Guangdong
-? "45"
+? "GX"
 :
   name: Guangxi
   names:
     - "Guangxi Zhuang"
-? "46"
+? "HI"
 :
   name: Hainan
   names: Hainan
-? "50"
+? "CQ"
 :
   name: Chongqing
   names: Chongqing
-? "51"
+? "SC"
 :
   name: Sichuan
   names: Sichuan
-? "52"
+? "GZ"
 :
   name: Guizhou
   names: Guizhou
-? "53"
+? "YN"
 :
   name: Yunnan
   names: Yunnan
-? "54"
+? "XZ"
 :
   name: Xizang
   names:
     - Tibet
-? "61"
+? "SN"
 :
   name: Shaanxi
   names: Shaanxi
-? "62"
+? "GS"
 :
   name: Gansu
   names: Gansu
-? "63"
+? "QH"
 :
   name: Qinghai
   names: Qinghai
-? "64"
+? "NX"
 :
   name: Ningxia
   names:
     - "Ningxia Hui"
-? "65"
+? "XJ"
 :
   name: Xinjiang
   names:
     - Uighur
     - Uygur
-? "71"
+? "TW"
 :
   name: "Taiwan *"
   names: "Taiwan *"
-? "91"
+? "HK"
 :
   name: "Xianggang (zh) **"
   names:
     - Xianggang
     - Hongkong
-? "92"
+? "MO"
 :
   name: "Aomen (zh) ***"
   names: "Aomen (zh) ***"


### PR DESCRIPTION
https://namely.atlassian.net/browse/BR-5581
---
This PR updates the China State IDs based on a change that occurred in November 2017. This will allow for the states to be properly mapped on mobile.

See here for the changes: https://www.iso.org/obp/ui/#iso:code:3166:CN

Will make a PR to bump the gem version on HCM once this is merged.