### PR TITLE
BR-7979: Remove American Territories From Countries List

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -328,36 +328,6 @@ AR:
     - gn
   nationality: "Argentinean"
   subdivision_type: 'Province'
-AS:
-  continent: Australia
-  alpha2: AS
-  alpha3: ASM
-  country_code: "1"
-  currency: USD
-  international_prefix: "011"
-  ioc: ASA
-  latitude: "14 20 S"
-  longitude: "170 00 W"
-  name: "American Samoa"
-  names:
-    - "American Samoa"
-    - "Amerikanisch-Samoa"
-    - "Samoa américaines"
-    - "Samoa Americana"
-  national_destination_code_lengths:
-    - 3
-  national_number_lengths:
-    - 10
-  national_prefix: "1"
-  number: "016"
-  region: Oceania
-  subregion: "Polynesia"
-  un_locode: AS
-  languages:
-    - en
-    - sm
-  nationality: "American Samoan"
-  subdivision_type: 'State'
 AT:
   continent: Europe
   address_format: |-
@@ -2675,34 +2645,6 @@ GT:
     - es
   nationality: "Guatemalan"
   subdivision_type: 'Department'
-GU:
-  continent: Australia
-  alpha2: GU
-  alpha3: GUM
-  country_code: "1"
-  currency: USD
-  international_prefix: "011"
-  ioc: GUM
-  latitude: "13 28 N"
-  longitude: "144 47 E"
-  name: "Guam"
-  names:
-    - "Guam"
-  national_destination_code_lengths:
-    - 3
-  national_number_lengths:
-    - 10
-  national_prefix: "1"
-  number: "316"
-  region: Oceania
-  subregion: "Micronesia"
-  un_locode: GU
-  languages:
-    - en
-    - ch
-    - es
-  nationality: "Guamanian"
-  subdivision_type: 'State'
 GW:
   continent: Africa
   alpha2: GW
@@ -4395,36 +4337,6 @@ MO:
     - pt
   nationality: "Chinese"
   subdivision_type: 'State'
-MP:
-  continent: Australia
-  alpha2: MP
-  alpha3: MNP
-  country_code: "1"
-  currency: USD
-  international_prefix: "011"
-  ioc:
-  latitude: "15 12 N"
-  longitude: "145 45 E"
-  name: "Northern Mariana Islands"
-  names:
-    - "Northern Mariana Islands"
-    - "Nördliche Marianen"
-    - "Mariannes du Nord"
-    - "Islas Marianas del Norte"
-  national_destination_code_lengths:
-    - 3
-  national_number_lengths:
-    - 10
-  national_prefix: "1"
-  number: "580"
-  region: Oceania
-  subregion: "Micronesia"
-  un_locode: MP
-  languages:
-    - en
-    - ch
-  nationality: "American"
-  subdivision_type: 'State'
 MQ:
   continent: North America
   alpha2: MQ
@@ -5387,33 +5299,6 @@ PN:
   languages:
     - en
   nationality: "Pitcairn Islander"
-  subdivision_type: 'State'
-PR:
-  continent: North America
-  alpha2: PR
-  alpha3: PRI
-  country_code: "1"
-  currency: USD
-  international_prefix: "011"
-  ioc: PUR
-  latitude: "18 15 N"
-  longitude: "66 30 W"
-  name: "Puerto Rico"
-  names:
-    - "Puerto Rico"
-  national_destination_code_lengths:
-    - 3
-  national_number_lengths:
-    - 10
-  national_prefix: "1"
-  number: "630"
-  region: Americas
-  subregion: "Caribbean"
-  un_locode: PR
-  languages:
-    - es
-    - en
-  nationality: "Puerto Rican"
   subdivision_type: 'State'
 PS:
   continent: Asia
@@ -7087,35 +6972,6 @@ VG:
   region: Americas
   subregion: "Caribbean"
   un_locode: VG
-  languages:
-    - en
-  nationality: "Virgin Islander"
-  subdivision_type: 'State'
-VI:
-  continent: North America
-  alpha2: VI
-  alpha3: VIR
-  country_code: "1"
-  currency: USD
-  international_prefix: "011"
-  ioc: ISV
-  latitude: ""
-  longitude: ""
-  name: "Virgin Islands, U.S."
-  names:
-    - "Virgin Islands of the United States"
-    - "Amerikanische Jungferninseln"
-    - "Îles Vierges américaines"
-    - "Islas Vírgenes de los Estados Unidos"
-  national_destination_code_lengths:
-    - 3
-  national_number_lengths:
-    - 10
-  national_prefix: "1"
-  number: "850"
-  region: Americas
-  subregion: "Caribbean"
-  un_locode: VI
   languages:
     - en
   nationality: "Virgin Islander"

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -116,7 +116,7 @@ describe ISO3166::Country do
         countries.should be_an(Array)
         countries.first.should be_an(Array)
         countries.first.should have(2).fields
-        countries.should have(247).countries
+        countries.should have(242).countries
       end
 
       it 'alphabetizes the countries by the name' do
@@ -132,7 +132,7 @@ describe ISO3166::Country do
         countries.should be_an(Array)
         countries.first.should be_an(Array)
         countries.first.should have(3).fields
-        countries.should have(247).countries
+        countries.should have(242).countries
       end
     end
   end


### PR DESCRIPTION
https://namely.atlassian.net/browse/BR-7979

I have verified that no addresses in Namely have these set as a country. 

The American Territories we are removing are: American Somoa (AS), Guam (GU), Northern Mariana Islands (MP), Puerto Rico (PR), and the US Virgin Islands (VI). 

Namely/namely tests are here: https://github.com/namely/namely/pull/10206